### PR TITLE
refactor dict::contains to not throw but only return bool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,3 +62,10 @@ endif ()
 if (BUILD_DEMO)
   add_subdirectory(examples)
 endif ()
+
+
+message("cppdict CMAKE OPTION LIST ")
+message("Build doc    : " ${BUILD_DOC})
+message("Build demo   : " ${BUILD_DEMO})
+message("Build bench  : " ${BUILD_BENCH})
+message("Build test   : " ${BUILD_TEST})

--- a/include/dict.hpp
+++ b/include/dict.hpp
@@ -208,14 +208,7 @@ struct Dict
 
     bool contains(std::string key)
     {
-        if (std::holds_alternative<node_t>(data))
-            return std::get<node_t>(data).count(key) > 0;
-
-#ifndef NDEBUG
-        std::cout << __FILE__ << " " << __LINE__ << " " << currentKey << std::endl;
-#endif
-
-        throw std::runtime_error("cppdict: contains() has no a map");
+        return isNode() and std::get<node_t>(data).count(key);
     }
 
     std::size_t size() const noexcept

--- a/test/basic_dict_ops.cpp
+++ b/test/basic_dict_ops.cpp
@@ -78,3 +78,15 @@ TEST_CASE("Deals with both references and values", "[simple cppdict::Dict<int, d
     }
 
 }
+
+
+TEST_CASE("Contains expects true or false", "[simple cppdict::Dict<int, double, std::string>]")
+{
+    Dict dict;
+    dict["this"]["is"]["the"]["source"] = 3.14;
+
+    REQUIRE(dict["this"].contains("is"));
+    REQUIRE(!dict.contains("is"));
+    REQUIRE(dict["this"]["is"]["the"].contains("source"));
+    REQUIRE(!dict["this"]["is"]["the"]["source"].contains("nothing"));
+}


### PR DESCRIPTION
contains only true if this is node and has key
Print CMake options to screen on config